### PR TITLE
fix hkey cleanup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,10 +59,10 @@ def _find_msbuild_tool(tool="msbuild.exe", use_windows_sdk=False):
     paths_to_check = []
     hreg = _winreg.ConnectRegistry(None, _winreg.HKEY_LOCAL_MACHINE)
     try:
-        hkey = None
         for key_to_check in keys_to_check:
             sdk_name, key, value_name = key_to_check[:3]
             suffix = key_to_check[3] if len(key_to_check) > 3 else None
+            hkey = None
             try:
                 hkey = _winreg.OpenKey(hreg, key)
                 val, type_ = _winreg.QueryValueEx(hkey, value_name)
@@ -74,7 +74,8 @@ def _find_msbuild_tool(tool="msbuild.exe", use_windows_sdk=False):
             except WindowsError:
                 pass
             finally:
-                hkey.Close()
+                if hkey:
+                    hkey.Close()
     finally:
         hreg.Close()
 


### PR DESCRIPTION
fix for AttributeError: 'NoneType' object has no attribute 'Close', full Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\foo\AppData\Local\Temp\pip-clrr6blj-build\setup.py", line 99, in <module>
        _xbuild = "\"%s\"" % _find_msbuild_tool("msbuild.exe")
      File "C:\Users\foo\AppData\Local\Temp\pip-clrr6blj-build\setup.py", line 77, in _find_msbuild_tool
        hkey.Close()
    AttributeError: 'NoneType' object has no attribute 'Close'
